### PR TITLE
Allow other users and chown to context uid/gid on create...

### DIFF
--- a/passthrough.py
+++ b/passthrough.py
@@ -131,7 +131,7 @@ class Passthrough(Operations):
 
 
 def main(mountpoint, root):
-    FUSE(Passthrough(root), mountpoint, nothreads=True, foreground=True, **{'allow_other': True})
+    FUSE(Passthrough(root), mountpoint, nothreads=True, foreground=True, allow_other=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Thanks for the excellent example on doing a passthrough class for a python based fuse sample.

I wanted to use your example as a basis for triggering actions based on the creation of new files.  When I originally ran the script I discovered quickly that the mounted FUSE folder was only accessible by the user (uid) running the Python/FUSE process.  To allow for other users (uids) of the system to be able to access / read / write the folder the `**{'allow_other': True}` flag was needed.  Without that flag the folder would look like what follows to the ls command:

```
$ ls -l /mnt/fuse-mounts
ls: cannot access '/mnt/fuse-mounts/test': Permission denied
total 0
d????????? ? ?    ?    ?            ? test

```

Next, after resolving the "allow_other" issue I noticed that all files that were created were being created with the uid & gid of the python process running the passthrough script (in my case uid/gid=0).  A reference to the fuse_get_context function allows for the retrieval of the gid/uid of the user actually calling the create file  operation.  Then a quick os.chown() operation sets the gid/uid to that of the calling (context) user.