### PR TITLE
Fix reversed parameters in link() and symlink() implementations.

### DIFF
--- a/passthrough.py
+++ b/passthrough.py
@@ -82,13 +82,13 @@ class Passthrough(Operations):
         return os.unlink(self._full_path(path))
 
     def symlink(self, name, target):
-        return os.symlink(name, self._full_path(target))
+        return os.symlink(target, self._full_path(name))
 
     def rename(self, old, new):
         return os.rename(self._full_path(old), self._full_path(new))
 
     def link(self, target, name):
-        return os.link(self._full_path(target), self._full_path(name))
+        return os.link(self._full_path(name), self._full_path(target))
 
     def utimens(self, path, times=None):
         return os.utime(self._full_path(path), times)


### PR DESCRIPTION
Yes, it is a bit strange how fusepy reverses these parameters when
calling into the Operations object, but they are indeed reversed.

This patch fixes the example to work correctly when symlinking
or linking in the passthrough.