### PR TITLE
Referencing and linking to fusepy from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # python-fuse-sample
 
-This repo contains a very simple FUSE filesystem example in Python. It's the
+This repo contains a very simple FUSE filesystem example in Python, using the [fusepy] library. It's the
 code from a post I wrote a while back:
 
 https://www.stavros.io/posts/python-fuse-filesystem/
 
 If you see anything needing improvement or have any feedback, please open an
 issue.
+
+[fusepy]: https://github.com/fusepy/fusepy


### PR DESCRIPTION
First, I don't mean to be presumptuous with this PR.

However, considering your example, which would not look be out of place in https://github.com/fusepy/fusepy/tree/master/examples, it seems only fair that their work be at least referenced here.